### PR TITLE
MAINT fixed versions of pymeshlab and numpy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,6 +78,7 @@ RUN export PATH="/opt/miniconda-latest/bin:$PATH" \
     &&   pip install --no-cache-dir  \
              "-r" \
              "/headcase-pipeline/requirements.txt"" \
+    && pip install --upgrade numpy \
     && rm -rf ~/.cache/pip/* \
     && sync \
     && sed -i '$isource activate base' $ND_ENTRYPOINT

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pycortex
-pymeshlab
+pymeshlab==2021.7
 plyfile
 autograd
 numpy


### PR DESCRIPTION
Small changes to get the correct versions of pymeshlab and numpy.
Works for me with Docker.